### PR TITLE
Missing bugfix for Mac OS X version.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.4.1
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Tyler Kennedy'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.4.0'
+release = '1.4.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,8 @@ class BuildAssist(build_ext):
         # platform.mac_ver returns a result on platforms *other* than OS X,
         # make sure we're actually on it first...
         if self.platform == 'darwin':
-            return namedtuple('mac_ver', ['major', 'minor', 'bugfix'])(
-                *(int(v) for v in platform.mac_ver()[0].split('.'))
+            return namedtuple('mac_ver', ['major', 'minor'])(
+                *(int(v) for v in platform.mac_ver()[0].split('.')[:2])
             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ with open(os.path.join(root, 'README.md'), 'rb') as readme:
 setup(
     name='pysimdjson',
     packages=find_packages(),
-    version='1.4.0',
+    version='1.4.1',
     description='simdjson bindings for python',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
`platform.mac_ver()[0].split('.')` only returns `'major', 'minor'` but not `'bugfix'` on Mac OS X Mojave which prevents from installing. 