### PR TITLE
Readme show benchmark data more appealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,22 +111,22 @@ with open('sample.json', 'rb') as fin:
 
 Comparing the built-in json module `loads` on py3.7 to simdjson `loads`.
 
-| File | `json` time | `pysimdjson` time |
-| ---- | ----------- | ----------------- |
-| `jsonexamples/apache_builds.json` | 0.09916733999999999 | 0.074089268 |
-| `jsonexamples/canada.json` | 5.305393378 | 1.6547515810000002 |
-| `jsonexamples/citm_catalog.json` | 1.3718639709999998 | 1.0438697340000003 |
-| `jsonexamples/github_events.json` | 0.04840242700000097 | 0.034239397999998644 |
-| `jsonexamples/gsoc-2018.json` | 1.5382746889999996 | 0.9597240750000005 |
-| `jsonexamples/instruments.json` | 0.24350973299999978 | 0.13639699600000021 |
-| `jsonexamples/marine_ik.json` | 4.505123285000002 | 2.8965093270000004 |
-| `jsonexamples/mesh.json` | 1.0325923849999974 | 0.38916503499999777 |
-| `jsonexamples/mesh.pretty.json` | 1.7129034710000006 | 0.46509220500000126 |
-| `jsonexamples/numbers.json` | 0.16577519699999854 | 0.04843887400000213 |
-| `jsonexamples/random.json` | 0.6930746310000018 | 0.6175370539999996 |
-| `jsonexamples/twitter.json` | 0.6069602610000011 | 0.41049074900000093 |
-| `jsonexamples/twitterescaped.json` | 0.7587005720000022 | 0.41576198399999953 |
-| `jsonexamples/update-center.json` | 0.5577604210000011 | 0.4961777420000004 |
+| File | `json` time | `pysimdjson` time | speedup (rounded) |
+| ---- | ----------- | ----------------- | ------------------|
+| `jsonexamples/mesh.pretty.json` | 1.7129034710000006 | 0.46509220500000126 | 73% |
+| `jsonexamples/numbers.json` | 0.16577519699999854 | 0.04843887400000213 | 71% |
+| `jsonexamples/canada.json` | 5.305393378 | 1.6547515810000002 | 69% |
+| `jsonexamples/mesh.json` | 1.0325923849999974 | 0.38916503499999777 | 62% |
+| `jsonexamples/twitterescaped.json` | 0.7587005720000022 | 0.41576198399999953 | 45% |
+| `jsonexamples/instruments.json` | 0.24350973299999978 | 0.13639699600000021 | 44% |
+| `jsonexamples/gsoc-2018.json` | 1.5382746889999996 | 0.9597240750000005 | 38% |
+| `jsonexamples/marine_ik.json` | 4.505123285000002 | 2.8965093270000004 | 36% |
+| `jsonexamples/twitter.json` | 0.6069602610000011 | 0.41049074900000093 | 32% |
+| `jsonexamples/github_events.json` | 0.04840242700000097 | 0.034239397999998644 | 29% |
+| `jsonexamples/apache_builds.json` | 0.09916733999999999 | 0.074089268 | 24% |
+| `jsonexamples/citm_catalog.json` | 1.3718639709999998 | 1.0438697340000003 | 24% |
+| `jsonexamples/random.json` | 0.6930746310000018 | 0.6175370539999996 | 11% |
+| `jsonexamples/update-center.json` | 0.5577604210000011 | 0.4961777420000004 | 11% |
 
 Getting subsets of the document is significantly faster. For `canada.json`
 getting `.type` using the naive approach and the `items()` approach, average


### PR DESCRIPTION
added speedup percentages
sorted by speedup percentage column, to be able to see how much the improvement could be (11% to 75%) in a glance