### PR TITLE
Buffer support (turn homogeneous arrays into buffers; accelerated numpy support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ C++11-capable compiler to compile the sources:
 
     pip install 'pysimdjson[dev]' --no-binary :all:
 
-Both simddjson and pysimdjson support FreeBSD and Linux on ARM when built
+Both simdjson and pysimdjson support FreeBSD and Linux on ARM when built
 from source.
 
 ## ⚗ Development and Testing

--- a/docs/native.rst
+++ b/docs/native.rst
@@ -4,8 +4,8 @@ Native API
 .. currentmodule:: simdjson
 
 The native simdjson API offers significant performance improvements over the
-builtin-compatible API if only part of a document is of interest. Objects
-and arrays are returned as fake dicts (:class:`~Object`) and lists
+builtin-compatible API, especially if only part of a document is of interest.
+Objects and arrays are returned as fake dicts (:class:`~Object`) and lists
 (:class:`~Array`) that delay the creation of Python objects until they are
 accessed.
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,8 @@ setup(
             'python-rapidjson',
             'simplejson',
             'ujson',
-            'yyjson'
+            'yyjson',
+            'numpy'
         ]
     },
     ext_modules=[

--- a/simdjson/simdjson.cpp
+++ b/simdjson/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Fri 23 Oct 2020 09:30:48 EDT. Do not edit! */
+/* auto-generated on Sun Oct 25 19:17:26 EDT 2020. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 

--- a/simdjson/simdjson.h
+++ b/simdjson/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on Fri 23 Oct 2020 09:30:48 EDT. Do not edit! */
+/* auto-generated on Sun Oct 25 19:17:26 EDT 2020. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -3276,6 +3276,17 @@ public:
    */
   inline size_t size() const noexcept;
   /**
+   * Get the total number of slots used by this array on the tape.
+   *
+   * Note that this is not the same thing as `size()`, which reports the
+   * number of actual elements within an array (not counting its children).
+   *
+   * Since an element can use 1 or 2 slots on the tape, you can only use this
+   * to figure out the total size of an array (including its children,
+   * recursively) if you know its structure ahead of time.
+   **/
+  inline size_t slots() const noexcept;
+  /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
    * https://tools.ietf.org/html/rfc6901 standard, interpreting the current node
    * as the root of its own JSON document.
@@ -5816,6 +5827,9 @@ inline array::iterator array::end() const noexcept {
 }
 inline size_t array::size() const noexcept {
   return tape.scope_count();
+}
+inline size_t array::slots() const noexcept {
+  return tape.matching_brace_index() - tape.json_index;
 }
 inline simdjson_result<element> array::at_pointer(std::string_view json_pointer) const noexcept {
   if(json_pointer.empty()) { // an empty string means that we return the current node

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -115,3 +115,9 @@ def test_array_as_buffer(parser):
     assert view.readonly is False
     assert len(view) == 4
     assert view.itemsize == 8
+
+
+def test_array_slots(parser):
+    """Esure we're getting the correct number of tape slots."""
+    doc = parser.parse(b'[0, 1, 2, 3, 4, 5]')
+    assert doc.slots == 14

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -105,3 +105,10 @@ def test_array_as_buffer(parser):
     # Signed elements should error on cast.
     with pytest.raises(ValueError):
         doc['i'].as_buffer(of_type='u')
+
+    doc = parser.parse(b'''[[
+        [1.0, 2.0],
+        [3.0, 4.0]
+    ]]''')
+    view = memoryview(doc.as_buffer(of_type='d'))
+    print(len(view))

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -106,9 +106,12 @@ def test_array_as_buffer(parser):
     with pytest.raises(ValueError):
         doc['i'].as_buffer(of_type='u')
 
+    # Ensure n-dimensional arrays are flattened.
     doc = parser.parse(b'''[[
         [1.0, 2.0],
         [3.0, 4.0]
     ]]''')
     view = memoryview(doc.as_buffer(of_type='d'))
-    print(len(view))
+    assert view.readonly is False
+    assert len(view) == 4
+    assert view.itemsize == 8

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -26,9 +26,16 @@ def with_builtin(content):
     assert len(numpy.array(json.loads(content))) == 10001
 
 
+def with_orjson(content):
+    import numpy
+    import orjson
+
+    assert len(numpy.array(orjson.loads(content))) == 10001
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize('loader', [
-    with_buffer, without_buffer, with_builtin])
+    with_buffer, without_buffer, with_builtin, with_orjson])
 def test_array_to_numpy(benchmark, loader):
     """Test how quickly we can load a homogeneous array of floats into a
     numpy array."""

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,40 @@
+import json
+
+import pytest
+
+import simdjson
+
+
+def with_buffer(content):
+    import numpy
+
+    parser = simdjson.Parser()
+    doc = parser.parse(content)
+    assert len(numpy.frombuffer(doc.as_buffer(of_type='d'))) == 10001
+
+
+def without_buffer(content):
+    import numpy
+
+    parser = simdjson.Parser()
+    doc = parser.parse(content)
+    assert len(numpy.array(doc.as_list())) == 10001
+
+
+def with_builtin(content):
+    import numpy
+    assert len(numpy.array(json.loads(content))) == 10001
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('loader', [
+    with_buffer, without_buffer, with_builtin])
+def test_array_to_numpy(benchmark, loader):
+    """Test how quickly we can load a homogeneous array of floats into a
+    numpy array."""
+    with open('jsonexamples/numbers.json', 'rb') as src:
+        content = src.read()
+
+    benchmark.group = 'numpy array (deserialize)'
+    benchmark.extra_info['group'] = 'numpy'
+    benchmark(loader, content)


### PR DESCRIPTION
This is the first attempt at allowing a user to turn homogeneous arrays into buffer objects to be passed around, mostly to other C extensions. So far, the speedup is fantastic testing against our 147k numbers.json file.

This completely avoids Python object creation (except for a single object used for lifecycle management).

```
------------------------------------------------------------------------------------ benchmark 'numpy array (deserialize)': 4 tests ------------------------------------------------------------------------------------
Name (time in us)                              Min                   Max                  Mean             StdDev                Median                IQR            Outliers         OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_array_to_numpy[with_buffer]          217.5000 (1.0)        327.6000 (1.0)        237.8600 (1.0)      32.9811 (1.0)        229.7500 (1.0)      16.8000 (1.35)          1;1  4,204.1537 (1.0)          10           1
test_array_to_numpy[without_buffer]       581.8000 (2.67)     1,548.0000 (4.73)       598.5025 (2.52)     44.6935 (1.36)       588.1000 (2.56)     12.4000 (1.0)        46;100  1,670.8368 (0.40)       1075           1
test_array_to_numpy[with_orjson]          652.2000 (3.00)     1,816.1000 (5.54)       680.7824 (2.86)     82.8546 (2.51)       663.5500 (2.89)     15.2000 (1.23)        28;68  1,468.8982 (0.35)        782           1
test_array_to_numpy[with_builtin]       1,206.3000 (5.55)     1,850.8000 (5.65)     1,231.8581 (5.18)     45.2980 (1.37)     1,218.4500 (5.30)     18.2500 (1.47)        49;75    811.7818 (0.19)        780           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```