### PR TITLE
add setup_requires for setup.py

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        
+
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
@@ -56,11 +56,10 @@ jobs:
         sudo apt-get install -y
         build-essential
         clang-6.0
-        
+
     - name: Installing python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e '.[dev]'
         pip install -e '.[test]'
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         pip install wheel twine
-        pip install -e '.[dev]'
+        pip install -e .
 
     - name: Publishing
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,6 @@ jobs:
     - name: Installing python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e '.[dev]'
         pip install -e '.[test]'
 
     - name: Running tests

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Binary wheels are available for the following:
 If binary wheels are not available for your platform, you'll need a
 C++11-capable compiler to compile the sources:
 
-    pip install 'pysimdjson[dev]' --no-binary :all:
+    pip install pysimdjson --no-binary :all:
 
 Both simdjson and pysimdjson support FreeBSD and Linux on ARM when built
 from source.
@@ -47,7 +47,7 @@ from source.
 This project comes with a full test suite. To install development and testing
 dependencies, use:
 
-    pip install -e ".[dev]"
+    pip install -e ".[test]"
 
 To also install 3rd party JSON libraries used for running benchmarks, use:
 
@@ -290,4 +290,3 @@ each file. The second approach avoids all unnecessary object creation.
 [simdjson]: https://github.com/lemire/simdjson
 [pybind11]: https://pybind11.readthedocs.io/en/stable/
 [devprompt]: https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs
-

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,12 @@ setup(
         'Intended Audience :: Developers',
     ],
     python_requires='>3.4',
+    install_requires=[
+        "pybind11"
+    ],
+    setup_requires=[
+        "pybind11"
+    ],
     extras_require={
         # Dependencies for building from source.
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -85,10 +85,6 @@ setup(
         "pybind11"
     ],
     extras_require={
-        # Dependencies for building from source.
-        'dev': [
-            'pybind11'
-        ],
         # Dependencies for package release.
         'release': [
             'm2r',

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,6 @@ setup(
         'Intended Audience :: Developers',
     ],
     python_requires='>3.4',
-    install_requires=[
-        "pybind11"
-    ],
     setup_requires=[
         "pybind11"
     ],


### PR DESCRIPTION
Fixes #62

Addition of `setup_requires` to `setup.py` will install pybind11 before rest of the setup is processed.

Following advice in https://setuptools.readthedocs.io/en/latest/userguide/keywords.html?highlight=setup_requires#new-and-changed-setup-keywords

`(Note: projects listed in setup_requires will NOT be automatically installed on the system where the setup script is being run. They are simply downloaded to the ./.eggs directory if they’re not locally available already. If you want them to be installed, as well as being available when the setup script is run, you should add them to install_requires and setup_requires.)`

`[dev]` extras is removed and documentation is updated to reflect the changes.