### PR TITLE
Provide the ability to link to system simdjson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,20 @@ if build_with_cython and not CYTHON_AVAILABLE:
     )
     build_with_cython = False
 
+build_with_system_lib = os.getenv('BUILD_WITH_SYSTEM_LIB')
+
 macros = []
 compiler_directives = {}
+libraries = []
 sources = [
-    'simdjson/simdjson.cpp',
     'simdjson/errors.cpp',
 ]
+
+if build_with_system_lib:
+    libraries.append('simdjson')
+else:
+    sources.append('simdjson/simdjson.cpp')
+
 if build_with_cython:
     compiler_directives['embedsignature'] = True
 
@@ -65,6 +73,7 @@ extensions = [
         sources,
         define_macros=macros,
         extra_compile_args=extra_compile_args,
+        libraries=libraries,
         language='c++',
     )
 ]


### PR DESCRIPTION
Bundling a library is a serious sin in our book, so provide the ability to link to the system library. I've also done some refactoring to avoid exponential growth of `Extension` calls. The default behavior remains the same, so it shouldn't affect existing users.

That said, the patch isn't perfect. It still uses the bundled headers instead of system headers but it should be good enough for us.