### PR TITLE
Docs: Fix JSON pointer typo

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -30,7 +30,7 @@ don't care about anything else. We can do this two ways:
 .. code:: python
 
     assert doc['res'][1]['name'] == 'second' # True
-    assert doc.at_pointer('res/1/name') == 'second' # True
+    assert doc.at_pointer('/res/1/name') == 'second' # True
 
 Both of these approaches will be much faster than using `load/s()`, since
 they avoid loading the parts of the document we didn't care about.


### PR DESCRIPTION
The missing leading slash causes:
```
simdjson/csimdjson.pyx in csimdjson.Object.at_pointer()

ValueError: Invalid JSON pointer syntax.
```