### PR TITLE
fix(ci): wheels for Python 3.9 ARM and missing `errors.h` from MANIFEST for source build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - secure: 0pA9waJ8KLstYc9LdrJmUnQB2eqxCnEqBjZMWSU3t+NNfVyLVq+9+6aMFEbPtOD0LYSWFSAMOlyLvBmjaEzl82fu6yuJdkFmT9bYt3sBv9w+GnkHgQi7eom2gIWwcWx5PaSYx2CDrYBjCwBipK87tUoQCj+DuevqmunXSHDwVxf05k2KJB+23FlAtJDmbQi2VRS2shrMchemftOpbspyjS6sc9RZBWj/RhUyISeuDi+2yk+2HRGhbGJ0G+S54pQFIlLc04E+QcpLKnH8qUWmf8zf+La5WAtOPLDCBOmbWM8UCJfDg4UZ2XQH2z6Er82DfY4oz+nU7qoKoFKJ7OTTgwI1yvsuXa/aYK2wqPQUGNv2kKA6zZOxlmMxFJumO0Ctri76LwyG+qD4aU3Ca+05tfedswAcatr9MXN2LLWLLSjX8rSIW8hQmQ2PItP68ZXWs5oxFCbpbD9Z/Wu1tD3m0eMDwoAWfUBeX8Zdxo4bBG8WzG9vJWDJo1Lqgjz/zibtf1PefCCdyxBsY/jTgxl2gtwbSqz50+7+2jB3KuBaU08uC/aq4BLQu1qdkrPYkQQDjTgcRIrM1gn9cVuLUoGnFwcm8RHhEkY0IU529iIn0So0YrGvEFUPlEU/x9WlbLfWLms9UnmTqkeR4E3YnOTpP8Avb9PWL6G62cTukwPN2ic=
 
 install:
-- python3 -m pip install cibuildwheel==1.5.2
+- python3 -m pip install cibuildwheel==1.11.1.post1
 
 script:
 - python3 -m cibuildwheel --output-dir wheelhouse

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include simdjson/binding.cpp
 include simdjson/simdjson.h
 include simdjson/simdjson.cpp
+include simdjson/errors.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include simdjson/binding.cpp
 include simdjson/simdjson.h
 include simdjson/simdjson.cpp
 include simdjson/errors.h
+include simdjson/errors.cpp

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ else:
 setup(
     name='pysimdjson',
     packages=find_packages(),
-    version='4.0.0',
+    version='4.0.1',
     description='simdjson bindings for python',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Resolves #84.