### PR TITLE
Add missing load and loads definitions in __init__.pyi

### DIFF
--- a/simdjson/__init__.pyi
+++ b/simdjson/__init__.pyi
@@ -128,6 +128,14 @@ class Parser:
         ...
 
 
+def loads(s, *, cls=None, object_hook=None, parse_float=None,
+        parse_int=None, parse_constant=None, object_pairs_hook=None, **kw): ...
+
+
+def load(fp, *, cls=None, object_hook=None, parse_float=None, parse_int=None,
+         parse_constant=None, object_pairs_hook=None, **kwargs): ...
+
+
 dumps = json.dumps
 dump = json.dump
 


### PR DESCRIPTION
#103 

I just copied the definitions in `__init__.py` and that's all.