### PR TITLE
v6.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setting up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -54,12 +54,12 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         # cp - CPython
         # pp - PyPy
-        py: ["cp36", "cp37", "cp38", "cp39", "cp310", "pp37", "pp38", "pp39"]
+        py: ["cp38", "cp39", "cp310", "cp311", "pp37", "pp38", "pp39"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Setting up Python
         with:
           python-version: '3.8'
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setting up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - uses: actions/checkout@v2
 
@@ -18,7 +18,7 @@ jobs:
       run: >
         sudo apt-get install -y
         build-essential
-        clang-6.0
+        clang-17
 
     - name: Installing python dependencies
       env:
@@ -49,13 +49,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       # Python needs to be setup before checkout to prevent files from being
       # left in the source tree. See setup-python/issues/106.
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -66,7 +66,7 @@ jobs:
       run: >
         sudo apt-get install -y
         build-essential
-        clang-6.0
+        clang-17
 
     - name: Installing python dependencies
       env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If SIMD instructions are unavailable a fallback parser is used, making
 pysimdjson safe to use anywhere.
 
 Bindings are currently tested on OS X, Linux, and Windows for Python version
-3.6 to 3.9.
+3.8 to 3.11.
 
 ## 📝 Documentation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ If SIMD instructions are unavailable a fallback parser is used, making
 pysimdjson safe to use anywhere.
 
 Bindings are currently tested on OS X, Linux, and Windows for Python version
-3.6 to 3.10.
+3.8 to 3.11.
 
 Installation
 ------------
@@ -44,15 +44,13 @@ Binary wheels are available for the following:
 +--------------+-------+-------+-------+---------+---------+
 | Interpreter  | OS X  |  Win  | Linux | Linux   | Linux   |
 +==============+=======+=======+=======+=========+=========+
-| CPython 3.6  | Yes   | Yes   | Yes   | Yes     | Yes     |
-+--------------+-------+-------+-------+---------+---------+
-| CPython 3.7  | Yes   | Yes   | Yes   | Yes     | Yes     |
-+--------------+-------+-------+-------+---------+---------+
 | CPython 3.8  | Yes   | Yes   | Yes   | Yes     | Yes     |
 +--------------+-------+-------+-------+---------+---------+
 | CPython 3.9  | Yes   | Yes   | Yes   | Yes     | Yes     |
 +--------------+-------+-------+-------+---------+---------+
 | CPython 3.10 | Yes   | Yes   | Yes   | Yes     | Yes     |
++--------------+-------+-------+-------+---------+---------+
+| CPython 3.11 | Yes   | Yes   | Yes   | Yes     | Yes     |
 +--------------+-------+-------+-------+---------+---------+
 
 When binary wheels are not available, a C++11 (or better) compiler is required


### PR DESCRIPTION
- Drop Python 3.6 and 3.7, which are now beyond end-of-life. Add Python 3.11.