### PR TITLE
Add load and loads to type stubs

### DIFF
--- a/simdjson/__init__.pyi
+++ b/simdjson/__init__.pyi
@@ -128,6 +128,8 @@ class Parser:
         ...
 
 
+loads = json.loads
+load = json.load
 dumps = json.dumps
 dump = json.dump
 


### PR DESCRIPTION
The load and loads methods aren't included in the typestubs, so pyright complains when users use them:

```
foo.py:45:28 - error: "load" is not a known member of module "simdjson" (reportAttributeAccessIssue)
```
