### PR TITLE
simdjson/simdjson.h: fix with clang 19

### DIFF
--- a/simdjson/simdjson.h
+++ b/simdjson/simdjson.h
@@ -6223,15 +6223,15 @@ public:
   simdjson_inline void one_char(char c);
 
   simdjson_inline void call_print_newline() {
-      this->print_newline();
+      static_cast<formatter*>(this)->print_newline();
   }
 
   simdjson_inline void call_print_indents(size_t depth) {
-      this->print_indents(depth);
+      static_cast<formatter*>(this)->print_indents(depth);
   }
 
   simdjson_inline void call_print_space() {
-      this->print_space();
+      static_cast<formatter*>(this)->print_space();
   }
 
 protected:


### PR DESCRIPTION
Patch for simdjson by Dimitry Andric <dim@FreeBSD.org> borrowed from https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=280590 .

See also https://github.com/simdjson/simdjson/commit/5d35e7ca .