### PR TITLE
Don't depend on self.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "pysimdjson",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
Remove self dependency in poetry pyproject.toml.

Without this, when `poetry add`, you get the following error:

```sh
$ poetry add pysimdjson
Using version ^7.0.1 for pysimdjson

Updating dependencies
Resolving dependencies... (0.0s) 
 
Package 'pysimdjson' is listed as a dependency of itself.
```