### PR TITLE
Restore PyPI classifiers and license metadata in pyproject.toml (fixes #131)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,27 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pysimdjson"
 version = "7.0.2"
-description = "Add your description here"
+description = "simdjson bindings for python"
 readme = "README.md"
 requires-python = ">=3.9"
+authors = [
+    { name = "Tyler Kennedy", email = "tk@tkte.ch" },
+]
+keywords = ["json", "simdjson", "simd"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+]
 dependencies = [
 ]
+
+[project.urls]
+Homepage = "https://github.com/TkTech/pysimdjson"
+Source = "https://github.com/TkTech/pysimdjson"
+Issues = "https://github.com/TkTech/pysimdjson/issues"
 
 [tool.uv.sources]
 pysimdjson = { workspace = true }


### PR DESCRIPTION
The README license badge (`img.shields.io/pypi/l/pysimdjson`) shows up as "missing" because it reads the license from the PyPI Trove classifiers, and those got dropped when `setup.py` was migrated to `pyproject.toml` in v7 (#124). You already spotted this in the issue.

This restores the metadata that was in the old `setup.py` but never carried over:

- `License :: OSI Approved :: MIT License` classifier (the one the badge needs) plus the other classifiers
- a real `description` instead of the leftover "Add your description here" placeholder
- author, keywords and project URLs

I verified it by building the sdist and checking `PKG-INFO`, which now includes:

```
Summary: simdjson bindings for python
Author-email: Tyler Kennedy <tk@tkte.ch>
Keywords: json,simdjson,simd
Classifier: License :: OSI Approved :: MIT License
```

I kept `Development Status :: 3 - Alpha` to match what was there before, happy to bump it if you'd rather it reflect the current maturity.

Fixes #131