### PR TITLE
Return False for non-string keys in Object.__contains__ (fixes #122)

### DIFF
--- a/simdjson/csimdjson.pyx
+++ b/simdjson/csimdjson.pyx
@@ -312,6 +312,12 @@ cdef class Object:
         return self.c_element.size()
 
     def __contains__(self, key):
+        # JSON object keys are always strings, so anything that isn't a
+        # str/bytes can't possibly be a key. Return False instead of letting
+        # str_as_bytes hand a bad type to the C++ layer (which raised a
+        # TypeError before), matching how a plain dict behaves.
+        if not isinstance(key, (str, bytes)):
+            return False
         try:
             self.c_element[str_as_bytes(key)]
         except KeyError:

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -20,6 +20,10 @@ def test_object_abc_mapping(parser):
     # __contains__
     assert 'a' in doc
     assert 'd' not in doc
+    # Non-string keys can never be present and should return False rather
+    # than raising, just like a regular dict (see issue #122).
+    assert None not in doc
+    assert 1 not in doc
     # __getitem__
     # Individual key access returns proxy objects.
     assert isinstance(doc['x'], simdjson.Object)


### PR DESCRIPTION
Checking a non-string key against a parsed `Object` currently raises `TypeError: expected bytes, NoneType found` instead of returning `False`. This came up in #122.

```python
import simdjson
parser = simdjson.Parser()
doc = parser.parse(b'{"res": [{"name": "first"}]}')
None in doc  # raised TypeError before this change
```

The key was handed straight to the C++ layer, which only accepts bytes. A regular dict returns `False` for a key like `None`, and `simdjson.loads` (which builds a real dict) already does too, so the parsed `Object` was the odd one out.

JSON object keys are always strings, so any key that isn't a `str` or `bytes` can't be present. I added a short circuit in `__contains__` that returns `False` for those, which lines the parsed `Object` up with dict behavior.

### Testing

Extended `test_object_abc_mapping` to assert `None not in doc` and `1 not in doc`. Full suite passes locally (22 passed, 4 skipped).