### PR TITLE
Restore package classifiers and metadata lost in pyproject.toml migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,27 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pysimdjson"
 version = "7.0.2"
-description = "Add your description here"
+description = "Python bindings for the simdjson project, a SIMD-accelerated JSON parser."
 readme = "README.md"
 requires-python = ">=3.9"
+license = {text = "MIT"}
+authors = [
+    {name = "Tyler Kennedy", email = "tk@tkte.ch"},
+]
+keywords = ["json", "simdjson", "simd"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+]
 dependencies = [
 ]
+
+[project.urls]
+Homepage = "https://github.com/TkTech/pysimdjson"
+Documentation = "https://pysimdjson.tkte.ch"
 
 [tool.uv.sources]
 pysimdjson = { workspace = true }


### PR DESCRIPTION
Fixes #131.

The migration from `setup.py` to `pyproject.toml` in #124 dropped a
chunk of the project metadata that used to be set in `setup.py`:
classifiers, license, author, and keywords. This included the
`License :: OSI Approved :: MIT License` classifier, which is what
the PyPI license badge in the README depends on to render (hence the
"license missing???" report). It also left the placeholder
`description = "Add your description here"` in place.

This restores that metadata in `[project]`:

- `license`, `authors`, `keywords`, `classifiers` (carried over from
  the old `setup.py`)
- A real `description`
- `[project.urls]` for the homepage and docs, since those were also
  present in the old `setup.py` via `url=`

Verified locally that `pip install -e .` and `python -m build --sdist`
both produce a `PKG-INFO`/`egg-info` with the classifiers and license
populated correctly, and the full test suite still passes.